### PR TITLE
Improve UI and add solution request when no solutions found

### DIFF
--- a/src/exceptionite/assets/App.vue
+++ b/src/exceptionite/assets/App.vue
@@ -27,6 +27,7 @@
       </div>
 
       <first-solution v-if="firstSolution" :solution="firstSolution" class="mt-4" />
+      <no-solution v-else-if="!firstSolution && showSolutionRequest" class="mt-4" :link="requestLink" @click="showSolutionRequest = false" />
 
       <stack id="stack" class="mt-4 mb-10" :exception="exception" />
 
@@ -78,6 +79,7 @@ import Exception from '@/components/Exception.vue'
 import Stack from '@/components/Stack.vue'
 import ContextMenu from '@/components/ContextMenu.vue'
 import FirstSolution from '@/components/FirstSolution.vue'
+import NoSolution from '@/components/NoSolution.vue'
 import Pulse from '@/components/Pulse.vue'
 import ShareDialog from '@/components/ShareDialog.vue'
 import BaseActionDialog from '@/components/BaseActionDialog.vue'
@@ -93,6 +95,7 @@ export default {
     BaseActionDialog,
     Pulse,
     FirstSolution,
+    NoSolution,
   },
   props: {
     config: { required: true },
@@ -125,16 +128,16 @@ export default {
     const selectedAction = ref(null)
 
     // solutions enabled ?
+    const solutionsTab = props.tabs.find(tab => tab.id == "solutions")
+    const possibleSolutions = solutionsTab !== undefined && solutionsTab.blocks.find(block => block.id === "possible_solutions")
+    const requestLink = ref(possibleSolutions?.data?.request_link || "#")
     const firstSolution = computed(() => {
-      const solutionsTab = props.tabs.find(tab => tab.id == "solutions")
-      if (solutionsTab !== undefined) {
-        const possibleSolutions = solutionsTab.blocks.find(block => block.id === "possible_solutions")
-        if (possibleSolutions !== undefined) {
-          return possibleSolutions.data.first
-        }
+      if (possibleSolutions !== undefined) {
+        return possibleSolutions.data.first
       }
       return false
     })
+    const showSolutionRequest = ref(true)
 
     // prepare default sharing settings
     const shareOptions = ref({
@@ -169,6 +172,8 @@ export default {
       // action handling
       selectedAction,
       firstSolution,
+      showSolutionRequest,
+      requestLink,
     }
   },
   methods: {

--- a/src/exceptionite/assets/app.css
+++ b/src/exceptionite/assets/app.css
@@ -247,6 +247,14 @@
   @apply cursor-not-allowed text-gray-300 dark:text-gray-700 dark:border-gray-700 dark:hover:text-gray-700 dark:hover:border-gray-700 hover:bg-transparent dark:hover:bg-gray-900;
 }
 
+.btn-solution {
+  @apply bg-transparent dark:bg-transparent border-green-700 text-green-700 dark:text-white dark:border-white dark:hover:bg-blue-900 hover:bg-green-300 hover:border-green-700 hover:text-green-700;
+}
+
+.btn-no-solution {
+  @apply bg-transparent dark:bg-transparent border-yellow-700 text-yellow-700 dark:text-yellow-900 dark:border-yellow-900 dark:hover:bg-yellow-700 hover:bg-yellow-100 hover:border-yellow-700 hover:text-yellow-700;
+}
+
 /* lists */
 .definition-list {
   @apply grid;

--- a/src/exceptionite/assets/components/FirstSolution.vue
+++ b/src/exceptionite/assets/components/FirstSolution.vue
@@ -14,9 +14,16 @@
       <p class="text-sm text-green-700 dark:text-gray-300">
         {{ solution.description }}
       </p>
-      <div class="text-sm text-green-700 dark:text-gray-300 underline pt-2" v-if="solution.doc_link">
-        Related Documentation: <a target="_blank" :href="solution.doc_link"> {{ solution.doc_link }} </a>
-      </div>
+      <a
+        v-if="solution.doc_link"
+        target="_blank"
+        :href="solution.doc_link"
+        class="btn btn-solution mt-2"
+        v-tooltip="`Open Masonite documentation related to this issue`"
+      >
+        <SolidInformationCircleIcon class="-ml-0.5 mr-2 h-4 w-4" />
+        Open Related Documentation
+      </a>
     </div>
   </div>
 </template>

--- a/src/exceptionite/assets/components/NoSolution.vue
+++ b/src/exceptionite/assets/components/NoSolution.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="rounded-md bg-yellow-50 dark:ring-1 dark:ring-inset dark:ring-white/10 p-4 dark:bg-yellow-600">
+    <div class="flex items-center mb-2">
+      <div class="flex-shrink-0">
+        <SolidExclamationCircleIcon class="h-5 w-5 text-yellow-400 dark:text-yellow-900" />
+      </div>
+      <div class="ml-2">
+        <p class="text-md font-medium text-yellow-600 dark:text-yellow-900">
+          No solution proposed for your error ?
+        </p>
+      </div>
+      <div class="ml-auto pl-3">
+        <div class="-mx-1.5 -my-1.5">
+          <button type="button" @click="$emit('click')" class="inline-flex bg-transparent rounded-md p-1.5 text-yellow-600 dark:text-yellow-900 hover:bg-yellow-100 focus:outline-none dark:hover:bg-yellow-700">
+            <span class="sr-only">Dismiss</span>
+            <XIcon class="h-5 w-5" aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+    </div>
+    <div>
+      <p class="text-sm text-yellow-700 dark:text-yellow-900">
+        It looks like we have not found a solution for this error. You can request as solution for this
+        error if you want by clicking the button below.
+      </p>
+      <a
+        target="_blank"
+        :href="link"
+        class="btn btn-no-solution mt-2"
+        v-tooltip="`Open an issue to add a solution for this exception`"
+      >
+        <SolidInformationCircleIcon class="-ml-0.5 mr-2 h-4 w-4" />
+        Open a Solution Request
+      </a>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "NoSolution",
+  props: {
+    link: {
+      type: String,
+      required: true
+    }
+  },
+  emits: ["click"]
+}
+</script>

--- a/src/exceptionite/assets/components/NoSolution.vue
+++ b/src/exceptionite/assets/components/NoSolution.vue
@@ -20,7 +20,7 @@
     </div>
     <div>
       <p class="text-sm text-yellow-700 dark:text-yellow-900">
-        It looks like we have not found a solution for this error. You can request as solution for this
+        It looks like we have not found a solution for this error. You can request to display a solution for this
         error if you want by clicking the button below.
       </p>
       <a

--- a/src/exceptionite/assets/components/Sponsor.vue
+++ b/src/exceptionite/assets/components/Sponsor.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="bg-white dark:bg-gray-800 dark:text-gray-300 rounded-md p-2 w-full text-black mb-4 shadow-md">
+  <div class="bg-white dark:bg-gray-800 dark:text-gray-300 rounded-md py-2 px-4 w-full text-black mb-4 shadow-md">
     <p>
       ❤️ Find this page useful?
       <a

--- a/src/exceptionite/assets/components/blocks/PossibleSolutions.vue
+++ b/src/exceptionite/assets/components/blocks/PossibleSolutions.vue
@@ -17,9 +17,16 @@
       >
         <template #title>{{ solution.title }}</template>
         <div>{{ solution.description }}</div>
-        <div class="text-sm text-green-700 dark:text-gray-300 underline pt-2" v-if="solution.doc_link">
-          Related Documentation: <a target="_blank" :href="solution.doc_link"> {{ solution.doc_link }} </a>
-        </div>
+        <a
+          v-if="solution.doc_link"
+          target="_blank"
+          :href="solution.doc_link"
+          class="btn btn-solution mt-2"
+          v-tooltip="`Open Masonite documentation related to this issue`"
+        >
+          <SolidInformationCircleIcon class="-ml-0.5 mr-2 h-4 w-4" />
+          Open Related Documentation
+        </a>
       </alert>
       <p v-if="!block.has_content" class="text-black dark:text-gray-400">{{ block.empty_msg || "No content." }}</p>
     </DisclosurePanel>

--- a/src/exceptionite/blocks/Environment.py
+++ b/src/exceptionite/blocks/Environment.py
@@ -3,7 +3,6 @@ import platform
 import socket
 import os
 
-from ..exceptions import ContextParsingException
 from ..Block import Block
 
 
@@ -27,7 +26,8 @@ class Environment(Block):
             ip = socket.gethostbyname(socket.gethostname())
         except socket.gaierror:
             print(
-                """Exceptionite did not manage to fetch the IP address. Disable you VPN or add '127.0.0.1 YOUR_HOSTNAME' line in /etc/hosts file."""
+                "Exceptionite did not manage to fetch the IP address. Disable you VPN or add "
+                + "'127.0.0.1 YOUR_HOSTNAME' line in /etc/hosts file."
             )
             ip = "Error fetching the IP address (open your terminal)"
 

--- a/src/exceptionite/blocks/Environment.py
+++ b/src/exceptionite/blocks/Environment.py
@@ -26,10 +26,10 @@ class Environment(Block):
         try:
             ip = socket.gethostbyname(socket.gethostname())
         except socket.gaierror:
-            raise ContextParsingException(
-                "Exceptionite did not manage to fetch the IP address"
-                + "Disable you VPN or add '127.0.0.1 YOUR_HOSTNAME' line in /etc/hosts file."
+            print(
+                """Exceptionite did not manage to fetch the IP address. Disable you VPN or add '127.0.0.1 YOUR_HOSTNAME' line in /etc/hosts file."""
             )
+            ip = "Error fetching the IP address (open your terminal)"
 
         return {
             "Python Version": python_version,

--- a/src/exceptionite/blocks/PossibleSolutions.py
+++ b/src/exceptionite/blocks/PossibleSolutions.py
@@ -1,4 +1,5 @@
 import re
+import urllib.parse
 
 from attr import has
 
@@ -70,10 +71,24 @@ class PossibleSolutions(Block):
                     {"title": title, "description": description, "doc_link": doc_link}
                 )
 
+        # build request_link
+        request_link = ""
+        if not possible_solutions:
+            request_link = self.get_request_link()
+
         return {
             "first": possible_solutions[0] if len(possible_solutions) > 0 else None,
             "solutions": possible_solutions,
+            "request_link": request_link,
         }
+
+    def get_request_link(self):
+        params = {
+            "title": f"Add exceptionite solution for `{self.handler.exception()}`",
+            "body": f"A solution is missing:\nException namespace: `{self.handler.namespace()}`\nError message:\n```\n{self.handler.message()}\n```",
+            "label": "solution-request",
+        }
+        return f"https://github.com/MasoniteFramework/masonite/issues/new/?{urllib.parse.urlencode(params)}"
 
     def register(self, *solutions):
         self.registered_solutions += solutions

--- a/src/exceptionite/blocks/PossibleSolutions.py
+++ b/src/exceptionite/blocks/PossibleSolutions.py
@@ -1,8 +1,6 @@
 import re
 import urllib.parse
 
-from attr import has
-
 from ..Block import Block
 from .. import solutions
 
@@ -85,10 +83,10 @@ class PossibleSolutions(Block):
     def get_request_link(self):
         params = {
             "title": f"Add exceptionite solution for `{self.handler.exception()}`",
-            "body": f"A solution is missing:\nException namespace: `{self.handler.namespace()}`\nError message:\n```\n{self.handler.message()}\n```",
+            "body": f"A solution is missing:\nException namespace: `{self.handler.namespace()}`\nError message:\n```\n{self.handler.message()}\n```",  # noqa: E501
             "label": "solution-request",
         }
-        return f"https://github.com/MasoniteFramework/masonite/issues/new/?{urllib.parse.urlencode(params)}"
+        return f"https://github.com/MasoniteFramework/masonite/issues/new/?{urllib.parse.urlencode(params)}"  # noqa: E501
 
     def register(self, *solutions):
         self.registered_solutions += solutions


### PR DESCRIPTION
- Fixed minor UI details (open related doc button, sponsor banner padding)
<img width="933" alt="Capture d’écran 2022-04-14 à 18 26 58" src="https://user-images.githubusercontent.com/9897999/163432896-c703c3d1-9c3d-4932-9121-14bd59313791.png">

- Add solution request card when no solution, the button will open a pre-filled Masonite issue
<img width="1296" alt="Capture d’écran 2022-04-14 à 18 27 21" src="https://user-images.githubusercontent.com/9897999/163432777-82c009ac-aec9-467c-849e-a705b044fe8a.png">

<img width="1031" alt="image" src="https://user-images.githubusercontent.com/9897999/163432749-36883fb0-5817-4826-80e6-ea584d027662.png">

- Removed exception raised when no IP can be parsed, print error in terminal instead and add warning in IP line in error page

@josephmancuso what do you think ?

Fix #25 