### PR TITLE
set encoding

### DIFF
--- a/src/exceptionite/StackTrace.py
+++ b/src/exceptionite/StackTrace.py
@@ -42,7 +42,7 @@ class StackFrame:
         self.variables = variables
         self.method = frame_summary.name if frame_summary.name != "<module>" else "__main__"
 
-        with open(self.file) as fp:
+        with open(self.file, "r", encoding="utf-8") as fp:
             printer = pprint.PrettyPrinter(indent=4)
 
             self.file_contents = printer.pformat(fp.read()).split("\\n")[

--- a/src/exceptionite/renderers/WebRenderer.py
+++ b/src/exceptionite/renderers/WebRenderer.py
@@ -56,7 +56,7 @@ class WebRenderer:
         path = os.path.join(
             os.path.dirname(os.path.dirname(__file__)), "templates", "exceptionite.js"
         )
-        with open(path, "r") as f:
+        with open(path, "r", encoding="utf-8") as f:
             script = f.read()
 
         env = Environment(loader=PackageLoader("exceptionite", "templates"))


### PR DESCRIPTION
Closes #32 

I think if a system does not have a default encoding set (idk why they won't but i've seen this before) then any open commands will throw an encoding error. So i think we should set these opens to utf-8 encoding