### PR TITLE
Deprecate this repository: Exceptionite continues at masonitedev/exceptionite

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -10,47 +10,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
-      - name: Install dependencies
-        run: |
-          make init
-      - name: Set up Node.js 14
-        uses: actions/setup-node@v4
-        with:
-          node-version: "14.x"
-      - name: Install Dependencies
-        run: npm install --legacy-peer-deps
-      - name: Compile frontend assets
-        run: |
-          npm run production
-      # here we run tests after having compiled the assets, because tests can use it
-      - name: Publish only packages passing test
-        run: |
-          make test
-      # we need to use --allow-empty when compiled assets don't change from one version to the next
-      - name: Bump version with compiled assets
-        shell: bash
-        env:
-          RELEASE_VERSION: ${{ github.event.release.tag_name }}
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add -f src/exceptionite/templates/exceptionite.js
-          git add -f src/exceptionite/templates/exceptionite.css
-          git commit -m"Release $RELEASE_VERSION" --allow-empty
-      - name: Push compiled assets
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.event.release.target_commitish }}
-          # override the tag created by GitHub release, now this tag will contains the compiled assets
-          tags: true
-          force: true
-      - name: Publish package
+          python-version: "3.10"
+      - name: Build and publish
+        # The compiled frontend assets (src/exceptionite/templates/*.js|css)
+        # are committed in the repository, so no npm build is needed for a
+        # notice-only post release.
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
-          make publish
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+          python setup.py sdist bdist_wheel
+          twine upload dist/*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# ⚠️ This repository is no longer maintained
+
+> **Exceptionite development continues at [masonitedev/exceptionite](https://github.com/masonitedev/exceptionite)** as part of Masonite 5 (a new PyPI package name is coming soon).
+> This repository covers `exceptionite` ≤ 3.0.0, which will receive **no further updates** (including security fixes).
+>
+> - 📖 Masonite documentation: <https://docs.masonite.dev>
+>
+> ❤️ In memory of [Joseph "Joe" Mancuso](https://github.com/josephmancuso), creator of Masonite.
+
+---
 
 # Exceptionite
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         #   3 - Alpha
         #   4 - Beta
         #   5 - Production/Stable
-        "Development Status :: 5 - Production/Stable",
+        "Development Status :: 7 - Inactive",
         # Indicate who your project is intended for
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Build Tools",

--- a/src/exceptionite/__init__.py
+++ b/src/exceptionite/__init__.py
@@ -1,4 +1,14 @@
 # flake8: noqa F401
+import warnings
+
+warnings.warn(
+    "The 'exceptionite' package is unmaintained and will receive no further "
+    "updates. Exceptionite development continues at "
+    "https://github.com/masonitedev/exceptionite as part of Masonite 5.",
+    FutureWarning,
+    stacklevel=2,
+)
+
 from .Handler import Handler, DefaultOptions
 from .Block import Block
 from .Tab import Tab

--- a/src/exceptionite/version.py
+++ b/src/exceptionite/version.py
@@ -1,1 +1,1 @@
-__version__ = "3.0.0"
+__version__ = "3.0.0.post1"


### PR DESCRIPTION
Exceptionite development continues at [masonitedev/exceptionite](https://github.com/masonitedev/exceptionite) as part of Masonite 5 (new PyPI package name coming soon). This PR adds the deprecation banner to the README/PyPI page, emits a `FutureWarning` on import, bumps to `3.0.0.post1` (Inactive classifier) and reduces the publish workflow to build+twine — the compiled assets are committed, so the Node 14 build isn't needed for a notice-only post release. A `v3.0.0.post1` release follows.

❤️ In memory of Joe Mancuso.