### PR TITLE
Add deprecation banner: Exceptionite continues at masonitedev/exceptionite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# ⚠️ This repository is no longer maintained
+
+> **Exceptionite development continues at [masonitedev/exceptionite](https://github.com/masonitedev/exceptionite)** as part of Masonite 5 (a new PyPI package name is coming soon).
+> This repository covers `exceptionite` ≤ 3.0.0, which will receive **no further updates** (including security fixes).
+>
+> - 📖 Masonite documentation: <https://docs.masonite.dev>
+>
+> ❤️ In memory of [Joseph "Joe" Mancuso](https://github.com/josephmancuso), creator of Masonite.
+
+---
 
 # Exceptionite
 


### PR DESCRIPTION
README-only counterpart of #107 for the `master` default branch, so repository visitors see the notice.